### PR TITLE
feat: implement RulesAgent with hybrid retrieval

### DIFF
--- a/backend/services/subagents/__init__.py
+++ b/backend/services/subagents/__init__.py
@@ -5,7 +5,7 @@ for specialized AI agents that handle specific aspects of deckbuilding
 assistance.
 
 Subagent Types:
-- rules: Deckbuilding rules and card legality
+- rules: Deckbuilding rules and card legality (with hybrid retrieval)
 - state: Deck composition analysis
 - action_space: Card search and filtering
 - scenario: Scenario threats and preparation
@@ -17,7 +17,7 @@ from backend.services.subagents.base import (
     SubagentConfig,
     SubagentError,
     SubagentTimeoutError,
-    # Concrete implementations
+    # Basic implementations
     RulesSubagent,
     StateSubagent,
     ActionSpaceSubagent,
@@ -26,17 +26,32 @@ from backend.services.subagents.base import (
     create_subagent,
 )
 
+from backend.services.subagents.rules_agent import (
+    # Enhanced RulesAgent with hybrid retrieval
+    RulesAgent,
+    RulesQuery,
+    RulesResponse,
+    RulesRetriever,
+    create_rules_agent,
+)
+
 __all__ = [
     # Base classes and exceptions
     "BaseSubagent",
     "SubagentConfig",
     "SubagentError",
     "SubagentTimeoutError",
-    # Concrete implementations
+    # Basic implementations
     "RulesSubagent",
     "StateSubagent",
     "ActionSpaceSubagent",
     "ScenarioSubagent",
-    # Factory function
+    # Enhanced RulesAgent with hybrid retrieval
+    "RulesAgent",
+    "RulesQuery",
+    "RulesResponse",
+    "RulesRetriever",
+    # Factory functions
     "create_subagent",
+    "create_rules_agent",
 ]

--- a/backend/services/subagents/rules_agent.py
+++ b/backend/services/subagents/rules_agent.py
@@ -1,0 +1,795 @@
+"""RulesAgent with hybrid retrieval for deckbuilding rules.
+
+This module implements the RulesAgent subagent that handles deckbuilding rules,
+card restrictions, and game rule queries using a hybrid retrieval approach:
+
+1. Keyword search: Searches static files for relevant rule sections
+2. LLM summarization: Uses the subagent LLM to interpret and explain rules
+
+The agent can answer questions about:
+- Deckbuilding rule questions
+- Card legality for investigators
+- Class restrictions and card access
+- Signature card and weakness rules
+"""
+
+import re
+from pathlib import Path
+from typing import Any
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+
+from backend.models.subagent_models import SubagentMetadata, SubagentResponse
+from backend.services.subagents.base import (
+    BaseSubagent,
+    SubagentConfig,
+    SubagentState,
+)
+
+
+# =============================================================================
+# Input/Output Schemas
+# =============================================================================
+
+
+class RulesQuery(BaseModel):
+    """Input schema for rules queries.
+
+    Attributes:
+        question: The rules question to answer.
+        investigator_id: Optional investigator ID for investigator-specific rules.
+        card_ids: Optional list of card IDs being queried about.
+    """
+
+    question: str = Field(
+        description="The rules question to answer"
+    )
+    investigator_id: str | None = Field(
+        default=None,
+        description="Investigator ID for investigator-specific rules"
+    )
+    card_ids: list[str] | None = Field(
+        default=None,
+        description="Card IDs being queried about"
+    )
+
+
+class RulesResponse(SubagentResponse):
+    """Structured response for rules queries.
+
+    Extends SubagentResponse with rules-specific fields.
+
+    Attributes:
+        rule_text: The relevant rule excerpt from reference materials.
+        interpretation: Plain-language explanation of the rule.
+        applies_to: List of what this rule affects (cards, investigators, etc.).
+    """
+
+    rule_text: str = Field(
+        default="",
+        description="Relevant rule excerpt from reference materials"
+    )
+    interpretation: str = Field(
+        default="",
+        description="Plain-language explanation of the rule"
+    )
+    applies_to: list[str] = Field(
+        default_factory=list,
+        description="What this rule affects (cards, investigators, etc.)"
+    )
+
+    @classmethod
+    def from_base_response(
+        cls,
+        base_response: SubagentResponse,
+        rule_text: str = "",
+        interpretation: str = "",
+        applies_to: list[str] | None = None,
+    ) -> "RulesResponse":
+        """Create a RulesResponse from a base SubagentResponse.
+
+        Args:
+            base_response: The base response to extend.
+            rule_text: The relevant rule excerpt.
+            interpretation: Plain-language explanation.
+            applies_to: What the rule affects.
+
+        Returns:
+            RulesResponse with all fields populated.
+        """
+        return cls(
+            content=base_response.content,
+            confidence=base_response.confidence,
+            sources=base_response.sources,
+            metadata=base_response.metadata,
+            rule_text=rule_text,
+            interpretation=interpretation,
+            applies_to=applies_to or [],
+        )
+
+    @classmethod
+    def error_response(
+        cls,
+        error_message: str,
+        agent_type: str = "rules",
+        confidence: float = 0.0,
+    ) -> "RulesResponse":
+        """Create an error response for graceful degradation.
+
+        Args:
+            error_message: Description of the error.
+            agent_type: The agent type (default: "rules").
+            confidence: Confidence score (typically 0 for errors).
+
+        Returns:
+            A RulesResponse indicating an error occurred.
+        """
+        return cls(
+            content=error_message,
+            confidence=confidence,
+            sources=[],
+            metadata=SubagentMetadata(
+                agent_type=agent_type,
+                query_type="error",
+                extra={"error": True},
+            ),
+            rule_text="",
+            interpretation="",
+            applies_to=[],
+        )
+
+
+# =============================================================================
+# Keyword Search for Static Files
+# =============================================================================
+
+
+class RulesRetriever:
+    """Retrieves relevant rule sections from static files using keyword search.
+
+    The retriever searches through markdown files in the static directory
+    and returns sections that match the query keywords.
+    """
+
+    # Keywords mapped to relevant topics for better matching
+    TOPIC_KEYWORDS = {
+        "deckbuilding": [
+            "deck construction", "30 cards", "copies", "deckbuilding",
+            "include", "restriction", "level", "class"
+        ],
+        "actions": [
+            "action", "investigate", "move", "fight", "evade", "draw",
+            "resource", "play", "activate"
+        ],
+        "resources": [
+            "resource", "cost", "pay", "gain", "spend"
+        ],
+        "skills": [
+            "skill test", "difficulty", "success", "chaos", "token", "commit"
+        ],
+        "signature": [
+            "signature", "required", "weakness", "basic weakness"
+        ],
+        "class": [
+            "guardian", "seeker", "rogue", "mystic", "survivor", "neutral",
+            "class", "faction"
+        ],
+        "xp": [
+            "experience", "xp", "upgrade", "level", "advance"
+        ],
+        "taboo": [
+            "taboo", "mutated", "forbidden", "chained", "unchained"
+        ],
+    }
+
+    def __init__(self, static_dir: Path | None = None):
+        """Initialize the retriever.
+
+        Args:
+            static_dir: Path to static files directory. If None, uses default.
+        """
+        if static_dir is None:
+            self.static_dir = Path(__file__).parent.parent.parent / "static"
+        else:
+            self.static_dir = static_dir
+
+    def search(self, query: str, max_sections: int = 5) -> list[dict[str, str]]:
+        """Search static files for relevant rule sections.
+
+        Args:
+            query: The search query.
+            max_sections: Maximum number of sections to return.
+
+        Returns:
+            List of dicts with 'source', 'section', and 'content' keys.
+        """
+        results = []
+        query_lower = query.lower()
+
+        # Extract keywords from query
+        query_keywords = self._extract_keywords(query_lower)
+
+        # Search each static file
+        for file_path in self.static_dir.glob("*.md"):
+            sections = self._parse_markdown_sections(file_path)
+            for section in sections:
+                score = self._score_section(section, query_keywords, query_lower)
+                if score > 0:
+                    results.append({
+                        "source": file_path.name,
+                        "section": section["heading"],
+                        "content": section["content"],
+                        "score": score,
+                    })
+
+        # Sort by score and limit results
+        results.sort(key=lambda x: x["score"], reverse=True)
+        return [
+            {"source": r["source"], "section": r["section"], "content": r["content"]}
+            for r in results[:max_sections]
+        ]
+
+    def _extract_keywords(self, query: str) -> set[str]:
+        """Extract relevant keywords from a query.
+
+        Args:
+            query: The lowercased query string.
+
+        Returns:
+            Set of keywords found in the query.
+        """
+        keywords = set()
+
+        # Check each topic's keywords
+        for topic, topic_keywords in self.TOPIC_KEYWORDS.items():
+            for keyword in topic_keywords:
+                if keyword in query:
+                    keywords.add(keyword)
+                    # Also add the topic name for broader matching
+                    keywords.add(topic)
+
+        # Add individual words from query (excluding common words)
+        stop_words = {
+            "the", "a", "an", "is", "are", "can", "could", "what", "how",
+            "why", "when", "where", "does", "do", "for", "to", "in", "of",
+            "and", "or", "but", "with", "this", "that", "it"
+        }
+        words = re.findall(r'\b\w+\b', query)
+        keywords.update(word for word in words if word not in stop_words and len(word) > 2)
+
+        return keywords
+
+    def _parse_markdown_sections(self, file_path: Path) -> list[dict[str, str]]:
+        """Parse a markdown file into sections.
+
+        Args:
+            file_path: Path to the markdown file.
+
+        Returns:
+            List of dicts with 'heading' and 'content' keys.
+        """
+        try:
+            content = file_path.read_text(encoding="utf-8")
+        except (OSError, IOError):
+            return []
+
+        sections = []
+        current_heading = "Introduction"
+        current_content = []
+
+        for line in content.split("\n"):
+            # Check for markdown headings
+            if line.startswith("#"):
+                # Save previous section if it has content
+                if current_content:
+                    sections.append({
+                        "heading": current_heading,
+                        "content": "\n".join(current_content).strip(),
+                    })
+
+                # Start new section
+                current_heading = line.lstrip("#").strip()
+                current_content = []
+            else:
+                current_content.append(line)
+
+        # Don't forget the last section
+        if current_content:
+            sections.append({
+                "heading": current_heading,
+                "content": "\n".join(current_content).strip(),
+            })
+
+        return sections
+
+    def _score_section(
+        self,
+        section: dict[str, str],
+        keywords: set[str],
+        query: str
+    ) -> float:
+        """Score a section based on keyword matches.
+
+        Args:
+            section: Section dict with 'heading' and 'content'.
+            keywords: Set of keywords to match.
+            query: The original query string.
+
+        Returns:
+            Relevance score (higher is better).
+        """
+        score = 0.0
+        heading_lower = section["heading"].lower()
+        content_lower = section["content"].lower()
+
+        # Heading matches are worth more
+        for keyword in keywords:
+            if keyword in heading_lower:
+                score += 3.0
+            if keyword in content_lower:
+                score += 1.0
+
+        # Exact phrase matches are worth even more
+        if len(query) > 5 and query in content_lower:
+            score += 5.0
+
+        # Boost for sections with substantial content
+        if len(section["content"]) > 100:
+            score *= 1.2
+
+        return score
+
+    def get_all_rules_content(self) -> str:
+        """Get all rules content concatenated.
+
+        Useful when no specific matches are found.
+
+        Returns:
+            Combined content from all static files.
+        """
+        content_parts = []
+        for file_path in sorted(self.static_dir.glob("*.md")):
+            try:
+                content = file_path.read_text(encoding="utf-8")
+                content_parts.append(f"# {file_path.stem}\n\n{content}")
+            except (OSError, IOError):
+                continue
+        return "\n\n---\n\n".join(content_parts)
+
+
+# =============================================================================
+# RulesAgent Implementation
+# =============================================================================
+
+
+class RulesAgent(BaseSubagent):
+    """RulesAgent with hybrid retrieval for deckbuilding rules.
+
+    This agent extends the base subagent pattern with:
+    1. Keyword search on static files to retrieve relevant rules
+    2. LLM summarization to interpret and explain the rules
+
+    The agent handles:
+    - Deckbuilding rule questions
+    - Card legality for investigators
+    - Class restrictions and card access
+    - Signature card and weakness rules
+    """
+
+    # Prompt template for the hybrid retrieval approach
+    HYBRID_PROMPT_TEMPLATE = """You are the Rules Agent, a specialist in Arkham Horror: The Card Game deckbuilding rules and card legality.
+
+## Retrieved Rule Context
+
+The following rule sections may be relevant to the user's question:
+
+{retrieved_rules}
+
+## Your Task
+
+Using the retrieved rules above (and your knowledge of Arkham Horror LCG rules), answer the user's question.
+
+When answering:
+1. **Cite specific rules** when explaining restrictions
+2. **Be precise** about level requirements and XP costs
+3. **Clarify edge cases** (e.g., Dunwich investigators, Versatile, etc.)
+4. **Distinguish** between "cannot include" vs "can include but shouldn't"
+
+## Response Format
+
+Structure your response as follows:
+- **Rule**: The specific rule or restriction that applies
+- **Interpretation**: A plain-language explanation
+- **Applies To**: What cards/investigators this affects
+
+{context_block}"""
+
+    def __init__(
+        self,
+        config: SubagentConfig | None = None,
+        retriever: RulesRetriever | None = None,
+    ) -> None:
+        """Initialize the RulesAgent.
+
+        Args:
+            config: Optional configuration for the subagent.
+            retriever: Optional custom retriever. If None, creates default.
+        """
+        super().__init__(agent_type="rules", config=config)
+        self.retriever = retriever or RulesRetriever()
+
+    def _prepare_prompt_node(self, state: SubagentState) -> dict[str, Any]:
+        """Prepare the system prompt with retrieved rules context.
+
+        This overrides the base implementation to inject retrieved rules
+        into the prompt for hybrid retrieval.
+
+        Args:
+            state: Current graph state with query and context.
+
+        Returns:
+            State update with formatted system prompt and updated context.
+        """
+        try:
+            # Retrieve relevant rules
+            retrieved_sections = self.retriever.search(state.query)
+
+            # Format retrieved rules
+            if retrieved_sections:
+                rules_text = "\n\n".join(
+                    f"### {section['section']} ({section['source']})\n{section['content']}"
+                    for section in retrieved_sections
+                )
+            else:
+                # Fall back to all content if no specific matches
+                rules_text = self.retriever.get_all_rules_content()
+                if not rules_text:
+                    rules_text = "*No rule documentation available*"
+
+            # Build context block
+            context_lines = []
+            if state.context.get("investigator_name"):
+                context_lines.append(
+                    f"**Investigator**: {state.context['investigator_name']}"
+                )
+            if state.context.get("deck_id"):
+                context_lines.append(f"**Deck ID**: {state.context['deck_id']}")
+
+            context_block = (
+                "## Current Context\n" + "\n".join(context_lines)
+                if context_lines
+                else ""
+            )
+
+            # Format the hybrid prompt
+            system_prompt = self.HYBRID_PROMPT_TEMPLATE.format(
+                retrieved_rules=rules_text,
+                context_block=context_block,
+            )
+
+            # Return both prompt and updated context with retrieved sections
+            updated_context = dict(state.context)
+            updated_context["_retrieved_sections"] = retrieved_sections
+
+            return {"system_prompt": system_prompt, "context": updated_context}
+        except Exception as e:
+            return {"error": f"Failed to prepare prompt: {e}"}
+
+    def _invoke_llm_node(self, state: SubagentState) -> dict[str, Any]:
+        """Invoke the LLM and create a RulesResponse.
+
+        This overrides the base implementation to return a RulesResponse
+        instead of a generic SubagentResponse.
+
+        Args:
+            state: Current graph state with prompt and query.
+
+        Returns:
+            State update with RulesResponse.
+        """
+        # Check for errors from previous nodes
+        if state.error:
+            return {
+                "response": RulesResponse.error_response(
+                    error_message=state.error,
+                    agent_type=self.agent_type,
+                )
+            }
+
+        # Build messages
+        messages = [
+            SystemMessage(content=state.system_prompt),
+            HumanMessage(content=state.query),
+        ]
+
+        try:
+            # Invoke LLM
+            result = self.llm.invoke(messages)
+
+            # Extract content
+            content = (
+                result.content
+                if isinstance(result.content, str)
+                else str(result.content)
+            )
+
+            # Parse response to extract structured fields
+            rule_text, interpretation, applies_to = self._parse_llm_response(content)
+
+            # Build sources from retrieved sections
+            retrieved = state.context.get("_retrieved_sections", [])
+            sources = self._extract_sources(content, state)
+            for section in retrieved:
+                source_ref = f"{section['section']} ({section['source']})"
+                if source_ref not in sources:
+                    sources.append(source_ref)
+
+            # Build response
+            response = RulesResponse(
+                content=content,
+                confidence=self._calculate_confidence(content, state),
+                sources=sources,
+                metadata=SubagentMetadata(
+                    agent_type=self.agent_type,
+                    query_type=self._determine_query_type(state.query),
+                    context_used={
+                        k: v
+                        for k, v in state.context.items()
+                        if v is not None and not k.startswith("_")
+                    },
+                    extra={
+                        "sections_retrieved": len(retrieved),
+                        "hybrid_retrieval": True,
+                    },
+                ),
+                rule_text=rule_text,
+                interpretation=interpretation,
+                applies_to=applies_to,
+            )
+            return {"response": response}
+
+        except Exception as e:
+            return {
+                "response": RulesResponse.error_response(
+                    error_message=f"LLM invocation failed: {e}",
+                    agent_type=self.agent_type,
+                )
+            }
+
+    def _parse_llm_response(self, content: str) -> tuple[str, str, list[str]]:
+        """Parse the LLM response to extract structured fields.
+
+        Looks for patterns like:
+        - **Rule**: <text>
+        - **Interpretation**: <text>
+        - **Applies To**: <text>
+
+        Args:
+            content: The LLM response content.
+
+        Returns:
+            Tuple of (rule_text, interpretation, applies_to list).
+        """
+        rule_text = ""
+        interpretation = ""
+        applies_to: list[str] = []
+
+        # Try to extract rule text
+        rule_match = re.search(
+            r'\*\*Rule\*\*:\s*(.+?)(?=\*\*|$)',
+            content,
+            re.IGNORECASE | re.DOTALL
+        )
+        if rule_match:
+            rule_text = rule_match.group(1).strip()
+
+        # Try to extract interpretation
+        interp_match = re.search(
+            r'\*\*Interpretation\*\*:\s*(.+?)(?=\*\*|$)',
+            content,
+            re.IGNORECASE | re.DOTALL
+        )
+        if interp_match:
+            interpretation = interp_match.group(1).strip()
+
+        # Try to extract applies_to
+        applies_match = re.search(
+            r'\*\*Applies To\*\*:\s*(.+?)(?=\*\*|$)',
+            content,
+            re.IGNORECASE | re.DOTALL
+        )
+        if applies_match:
+            applies_text = applies_match.group(1).strip()
+            # Split on commas or newlines
+            applies_to = [
+                item.strip().lstrip("- ")
+                for item in re.split(r'[,\n]', applies_text)
+                if item.strip()
+            ]
+
+        # If structured parsing didn't work, use the whole content
+        if not rule_text and not interpretation:
+            interpretation = content
+
+        return rule_text, interpretation, applies_to
+
+    def _calculate_confidence(
+        self, content: str, state: SubagentState
+    ) -> float:
+        """Calculate confidence for rules responses.
+
+        Higher confidence when:
+        - Retrieved sections were found
+        - Response contains definitive language
+        - Rule citations are present
+
+        Args:
+            content: The LLM response content.
+            state: The current graph state.
+
+        Returns:
+            Confidence score from 0.0 to 1.0.
+        """
+        content_lower = content.lower()
+        base_confidence = 0.5
+
+        # Boost for retrieved context
+        retrieved = state.context.get("_retrieved_sections", [])
+        if retrieved:
+            base_confidence += 0.15 * min(len(retrieved), 3) / 3
+
+        # High confidence indicators
+        if any(
+            phrase in content_lower
+            for phrase in [
+                "according to the rules",
+                "the rules state",
+                "rule reference",
+                "is legal",
+                "is not legal",
+                "cannot include",
+                "must include",
+            ]
+        ):
+            base_confidence += 0.2
+
+        # Medium confidence indicators
+        if any(
+            phrase in content_lower
+            for phrase in ["can include", "may include", "restricted to", "level 0-"]
+        ):
+            base_confidence += 0.1
+
+        # Penalty for uncertainty language
+        if any(
+            phrase in content_lower
+            for phrase in ["not sure", "unclear", "might be", "possibly", "i think"]
+        ):
+            base_confidence -= 0.15
+
+        return min(max(base_confidence, 0.1), 0.95)
+
+    def _extract_sources(
+        self, content: str, state: SubagentState
+    ) -> list[str]:
+        """Extract rule and card references from the response.
+
+        Args:
+            content: The LLM response content.
+            state: The current graph state.
+
+        Returns:
+            List of source references.
+        """
+        sources = []
+
+        # Add investigator as source if mentioned
+        investigator = state.context.get("investigator_name")
+        if investigator and investigator.lower() in content.lower():
+            sources.append(f"Investigator: {investigator}")
+
+        # Look for rule-related keywords
+        content_lower = content.lower()
+        if "taboo" in content_lower:
+            sources.append("Taboo List")
+        if "signature" in content_lower:
+            sources.append("Signature Card Rules")
+        if "weakness" in content_lower:
+            sources.append("Weakness Rules")
+        if "deck construction" in content_lower or "deckbuilding" in content_lower:
+            sources.append("Deck Construction Rules")
+
+        return sources
+
+    def _determine_query_type(self, query: str) -> str:
+        """Classify the type of rules query.
+
+        Args:
+            query: The user's query string.
+
+        Returns:
+            String identifier for the query type.
+        """
+        query_lower = query.lower()
+
+        # Check specific patterns first (order matters!)
+        if "taboo" in query_lower:
+            return "taboo_check"
+        if any(word in query_lower for word in ["signature", "required"]):
+            return "signature_rules"
+        if any(word in query_lower for word in ["weakness", "basic weakness"]):
+            return "weakness_rules"
+        # XP/level rules - check before legality since "level" is more specific
+        if any(word in query_lower for word in ["xp", "experience", "upgrade"]):
+            return "xp_rules"
+        if "level" in query_lower and "card" in query_lower:
+            return "xp_rules"
+        # Class access - check before generic legality
+        if any(word in query_lower for word in ["class", "faction"]):
+            return "class_access"
+        if "access" in query_lower and any(
+            word in query_lower for word in ["card", "what", "which"]
+        ):
+            return "class_access"
+        # Generic legality check
+        if any(word in query_lower for word in ["legal", "include", "can ", "allow"]):
+            return "legality_check"
+
+        return "general_rules"
+
+    def query_rules(
+        self,
+        rules_query: RulesQuery,
+        context: dict[str, Any] | None = None,
+    ) -> RulesResponse:
+        """Execute a rules query with the RulesQuery input schema.
+
+        This is a convenience method that accepts a RulesQuery object
+        and merges its fields into the context.
+
+        Args:
+            rules_query: The structured rules query.
+            context: Optional additional context.
+
+        Returns:
+            RulesResponse with the query result.
+        """
+        context = context or {}
+
+        # Merge RulesQuery fields into context
+        if rules_query.investigator_id:
+            context["investigator_id"] = rules_query.investigator_id
+        if rules_query.card_ids:
+            context["card_ids"] = rules_query.card_ids
+
+        # Execute query
+        response = self.query(rules_query.question, context)
+
+        # Ensure we return a RulesResponse
+        if isinstance(response, RulesResponse):
+            return response
+
+        # Convert SubagentResponse to RulesResponse
+        return RulesResponse.from_base_response(response)
+
+
+# =============================================================================
+# Factory function
+# =============================================================================
+
+
+def create_rules_agent(
+    config: SubagentConfig | None = None,
+    retriever: RulesRetriever | None = None,
+) -> RulesAgent:
+    """Create a configured RulesAgent instance.
+
+    Args:
+        config: Optional configuration for the subagent.
+        retriever: Optional custom retriever for rules lookup.
+
+    Returns:
+        Configured RulesAgent instance.
+    """
+    return RulesAgent(config=config, retriever=retriever)

--- a/tests/test_rules_agent.py
+++ b/tests/test_rules_agent.py
@@ -1,0 +1,593 @@
+"""Unit tests for the RulesAgent with hybrid retrieval."""
+
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.models.subagent_models import SubagentMetadata, SubagentResponse
+from backend.services.subagents.rules_agent import (
+    RulesAgent,
+    RulesQuery,
+    RulesResponse,
+    RulesRetriever,
+    create_rules_agent,
+)
+from backend.services.subagents.base import SubagentConfig
+
+
+# =============================================================================
+# RulesQuery Tests
+# =============================================================================
+
+
+class TestRulesQuery:
+    """Tests for RulesQuery input schema."""
+
+    def test_minimal_query(self):
+        """Should accept just a question."""
+        query = RulesQuery(question="Can Roland include Shrivelling?")
+        assert query.question == "Can Roland include Shrivelling?"
+        assert query.investigator_id is None
+        assert query.card_ids is None
+
+    def test_full_query(self):
+        """Should accept all fields."""
+        query = RulesQuery(
+            question="Can Roland include these cards?",
+            investigator_id="01001",
+            card_ids=["01016", "01017"],
+        )
+        assert query.question == "Can Roland include these cards?"
+        assert query.investigator_id == "01001"
+        assert query.card_ids == ["01016", "01017"]
+
+    def test_requires_question(self):
+        """Should require question field."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            RulesQuery()
+
+
+# =============================================================================
+# RulesResponse Tests
+# =============================================================================
+
+
+class TestRulesResponse:
+    """Tests for RulesResponse output schema."""
+
+    def test_minimal_response(self):
+        """Should create with required fields."""
+        response = RulesResponse(
+            content="Roland can include Guardian and Seeker cards.",
+            metadata=SubagentMetadata(agent_type="rules"),
+        )
+        assert response.content == "Roland can include Guardian and Seeker cards."
+        assert response.rule_text == ""
+        assert response.interpretation == ""
+        assert response.applies_to == []
+
+    def test_full_response(self):
+        """Should include all rules-specific fields."""
+        response = RulesResponse(
+            content="Full response text",
+            confidence=0.9,
+            sources=["Deck Construction Rules"],
+            metadata=SubagentMetadata(
+                agent_type="rules",
+                query_type="legality_check",
+            ),
+            rule_text="30 cards minimum, 0-2 copies per card",
+            interpretation="Roland can include up to 2 copies of most cards",
+            applies_to=["Roland Banks", "All investigators"],
+        )
+        assert response.confidence == 0.9
+        assert response.rule_text == "30 cards minimum, 0-2 copies per card"
+        assert response.interpretation == "Roland can include up to 2 copies of most cards"
+        assert "Roland Banks" in response.applies_to
+
+    def test_from_base_response(self):
+        """Should convert from base SubagentResponse."""
+        base = SubagentResponse(
+            content="Base content",
+            confidence=0.8,
+            sources=["Source 1"],
+            metadata=SubagentMetadata(agent_type="rules"),
+        )
+        rules_response = RulesResponse.from_base_response(
+            base,
+            rule_text="The rule text",
+            interpretation="The interpretation",
+            applies_to=["Card A", "Card B"],
+        )
+        assert rules_response.content == "Base content"
+        assert rules_response.confidence == 0.8
+        assert rules_response.rule_text == "The rule text"
+        assert rules_response.interpretation == "The interpretation"
+        assert rules_response.applies_to == ["Card A", "Card B"]
+
+    def test_error_response(self):
+        """Should create error response."""
+        response = RulesResponse.error_response("Something went wrong")
+        assert response.content == "Something went wrong"
+        assert response.confidence == 0.0
+        assert response.metadata.query_type == "error"
+        assert response.metadata.extra.get("error") is True
+        assert response.rule_text == ""
+        assert response.applies_to == []
+
+
+# =============================================================================
+# RulesRetriever Tests
+# =============================================================================
+
+
+class TestRulesRetriever:
+    """Tests for RulesRetriever keyword search."""
+
+    @pytest.fixture
+    def temp_static_dir(self):
+        """Create a temporary directory with test rules files."""
+        with TemporaryDirectory() as tmpdir:
+            static_dir = Path(tmpdir)
+
+            # Create test rules file
+            rules_file = static_dir / "rules_overview.md"
+            rules_file.write_text("""# Arkham Horror LCG Rules
+
+## Deck Construction
+
+- 30 cards minimum
+- 0-2 copies of each card (by title, not by level)
+- Must respect investigator's deckbuilding restrictions
+- Include required signature cards
+
+## Action Economy
+
+- Each investigator gets 3 actions per turn
+- Actions: Investigate, Move, Fight, Evade, Draw, Resource, Play card
+
+## Experience and Upgrades
+
+- Earn XP by completing scenarios
+- Spend XP to upgrade cards to higher levels
+- Level 0 cards are free, higher levels cost XP
+""")
+
+            # Create test meta file
+            meta_file = static_dir / "meta_trends.md"
+            meta_file.write_text("""# Meta Trends
+
+## Popular Archetypes
+
+- Guardian: Combat focused, tank role
+- Seeker: Investigation focused, clue gathering
+- Mystic: Spell-based, flexible
+""")
+
+            yield static_dir
+
+    def test_search_finds_relevant_sections(self, temp_static_dir):
+        """Should find sections matching keywords."""
+        retriever = RulesRetriever(static_dir=temp_static_dir)
+        results = retriever.search("deck construction copies")
+
+        assert len(results) > 0
+        # Should find the Deck Construction section
+        section_names = [r["section"] for r in results]
+        assert any("Deck Construction" in name for name in section_names)
+
+    def test_search_returns_content(self, temp_static_dir):
+        """Should return section content."""
+        retriever = RulesRetriever(static_dir=temp_static_dir)
+        results = retriever.search("actions")
+
+        assert len(results) > 0
+        # Should contain action-related content
+        all_content = " ".join(r["content"] for r in results)
+        assert "actions" in all_content.lower() or "action" in all_content.lower()
+
+    def test_search_limits_results(self, temp_static_dir):
+        """Should respect max_sections limit."""
+        retriever = RulesRetriever(static_dir=temp_static_dir)
+        results = retriever.search("card", max_sections=2)
+
+        assert len(results) <= 2
+
+    def test_search_scores_heading_matches_higher(self, temp_static_dir):
+        """Should rank heading matches higher than content matches."""
+        retriever = RulesRetriever(static_dir=temp_static_dir)
+        results = retriever.search("experience upgrades")
+
+        assert len(results) > 0
+        # Experience section should be ranked high
+        top_section = results[0]["section"]
+        assert "Experience" in top_section or "Upgrade" in top_section
+
+    def test_search_empty_query_returns_results(self, temp_static_dir):
+        """Should handle empty query gracefully."""
+        retriever = RulesRetriever(static_dir=temp_static_dir)
+        results = retriever.search("")
+
+        # May return results based on topic keywords or be empty
+        assert isinstance(results, list)
+
+    def test_get_all_rules_content(self, temp_static_dir):
+        """Should concatenate all rules content."""
+        retriever = RulesRetriever(static_dir=temp_static_dir)
+        content = retriever.get_all_rules_content()
+
+        assert "Deck Construction" in content
+        assert "Meta Trends" in content
+        assert "30 cards" in content
+
+    def test_handles_missing_directory(self):
+        """Should handle missing static directory gracefully."""
+        retriever = RulesRetriever(static_dir=Path("/nonexistent/path"))
+        results = retriever.search("anything")
+
+        assert results == []
+
+    def test_extract_keywords(self, temp_static_dir):
+        """Should extract relevant keywords from query."""
+        retriever = RulesRetriever(static_dir=temp_static_dir)
+        keywords = retriever._extract_keywords("can roland include level 2 guardian cards")
+
+        assert "level" in keywords or "guardian" in keywords
+        # Should also extract topic keywords
+        assert len(keywords) > 0
+
+
+# =============================================================================
+# RulesAgent Tests
+# =============================================================================
+
+
+class TestRulesAgent:
+    """Tests for RulesAgent with mocked LLM."""
+
+    @pytest.fixture
+    def mock_llm_response(self):
+        """Create a mock LLM response."""
+        mock_response = MagicMock()
+        mock_response.content = """**Rule**: Investigators must include at least 30 cards and can include 0-2 copies of each card by title.
+
+**Interpretation**: Roland Banks can include up to 2 copies of most Guardian and Seeker cards level 0-2, respecting his deckbuilding restrictions.
+
+**Applies To**: Roland Banks, All Guardian investigators"""
+        return mock_response
+
+    @pytest.fixture
+    def mock_retriever(self):
+        """Create a mock retriever with test data."""
+        retriever = MagicMock(spec=RulesRetriever)
+        retriever.search.return_value = [
+            {
+                "source": "rules_overview.md",
+                "section": "Deck Construction",
+                "content": "30 cards minimum, 0-2 copies per card",
+            }
+        ]
+        retriever.get_all_rules_content.return_value = "All rules content here"
+        return retriever
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch("backend.services.subagents.base.ChatOpenAI")
+    def test_agent_initialization(self, mock_chat, mock_retriever):
+        """Should initialize with retriever."""
+        agent = RulesAgent(retriever=mock_retriever)
+
+        assert agent.agent_type == "rules"
+        assert agent.retriever is mock_retriever
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch("backend.services.subagents.base.ChatOpenAI")
+    def test_query_returns_rules_response(
+        self, mock_chat_class, mock_retriever, mock_llm_response
+    ):
+        """Should return RulesResponse with structured fields."""
+        # Setup mock
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = mock_llm_response
+        mock_chat_class.return_value = mock_llm
+
+        agent = RulesAgent(retriever=mock_retriever)
+        response = agent.query("Can Roland include Shrivelling?")
+
+        assert isinstance(response, RulesResponse)
+        assert response.rule_text != ""
+        assert response.interpretation != ""
+        assert len(response.applies_to) > 0
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch("backend.services.subagents.base.ChatOpenAI")
+    def test_query_includes_retrieved_sections_in_sources(
+        self, mock_chat_class, mock_retriever, mock_llm_response
+    ):
+        """Should include retrieved sections in sources."""
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = mock_llm_response
+        mock_chat_class.return_value = mock_llm
+
+        agent = RulesAgent(retriever=mock_retriever)
+        response = agent.query("deck construction rules")
+
+        # Should have sources from retrieval
+        assert any("rules_overview.md" in s for s in response.sources)
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch("backend.services.subagents.base.ChatOpenAI")
+    def test_query_with_context(
+        self, mock_chat_class, mock_retriever, mock_llm_response
+    ):
+        """Should use context in prompt."""
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = mock_llm_response
+        mock_chat_class.return_value = mock_llm
+
+        agent = RulesAgent(retriever=mock_retriever)
+        response = agent.query(
+            "Can this investigator include Shrivelling?",
+            context={"investigator_name": "Roland Banks"},
+        )
+
+        # Verify LLM was called
+        assert mock_llm.invoke.called
+        # Check prompt includes context
+        call_args = mock_llm.invoke.call_args[0][0]
+        system_prompt = call_args[0].content
+        assert "Roland Banks" in system_prompt
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch("backend.services.subagents.base.ChatOpenAI")
+    def test_query_rules_method(
+        self, mock_chat_class, mock_retriever, mock_llm_response
+    ):
+        """Should accept RulesQuery input schema."""
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = mock_llm_response
+        mock_chat_class.return_value = mock_llm
+
+        agent = RulesAgent(retriever=mock_retriever)
+        rules_query = RulesQuery(
+            question="Can Roland include this card?",
+            investigator_id="01001",
+            card_ids=["01016"],
+        )
+        response = agent.query_rules(rules_query)
+
+        assert isinstance(response, RulesResponse)
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch("backend.services.subagents.base.ChatOpenAI")
+    def test_metadata_includes_hybrid_retrieval_flag(
+        self, mock_chat_class, mock_retriever, mock_llm_response
+    ):
+        """Should indicate hybrid retrieval was used."""
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = mock_llm_response
+        mock_chat_class.return_value = mock_llm
+
+        agent = RulesAgent(retriever=mock_retriever)
+        response = agent.query("deck construction rules")
+
+        assert response.metadata.extra.get("hybrid_retrieval") is True
+        assert response.metadata.extra.get("sections_retrieved") == 1
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch("backend.services.subagents.base.ChatOpenAI")
+    def test_handles_llm_error(self, mock_chat_class, mock_retriever):
+        """Should return error response on LLM failure."""
+        mock_llm = MagicMock()
+        mock_llm.invoke.side_effect = Exception("API Error")
+        mock_chat_class.return_value = mock_llm
+
+        agent = RulesAgent(retriever=mock_retriever)
+        response = agent.query("any question")
+
+        assert isinstance(response, RulesResponse)
+        assert "failed" in response.content.lower() or "error" in response.content.lower()
+        assert response.confidence == 0.0
+
+
+# =============================================================================
+# Query Type Classification Tests
+# =============================================================================
+
+
+class TestQueryTypeClassification:
+    """Tests for query type classification."""
+
+    @pytest.fixture
+    def agent(self, mock_retriever):
+        """Create agent with mocked dependencies."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            with patch("backend.services.subagents.base.ChatOpenAI"):
+                return RulesAgent(retriever=mock_retriever)
+
+    @pytest.fixture
+    def mock_retriever(self):
+        retriever = MagicMock(spec=RulesRetriever)
+        retriever.search.return_value = []
+        return retriever
+
+    def test_legality_check_query(self, agent):
+        """Should classify legality questions."""
+        assert agent._determine_query_type("Can Roland include Shrivelling?") == "legality_check"
+        assert agent._determine_query_type("Is Machete legal for Wendy?") == "legality_check"
+
+    def test_xp_rules_query(self, agent):
+        """Should classify XP questions."""
+        assert agent._determine_query_type("How much XP does Shrivelling (5) cost?") == "xp_rules"
+        assert agent._determine_query_type("What level cards can Roland access?") == "xp_rules"
+
+    def test_taboo_query(self, agent):
+        """Should classify taboo questions."""
+        assert agent._determine_query_type("Is Machete on the taboo list?") == "taboo_check"
+
+    def test_signature_query(self, agent):
+        """Should classify signature card questions."""
+        assert agent._determine_query_type("What is Roland's signature card?") == "signature_rules"
+
+    def test_weakness_query(self, agent):
+        """Should classify weakness questions."""
+        assert agent._determine_query_type("How do basic weaknesses work?") == "weakness_rules"
+
+    def test_class_access_query(self, agent):
+        """Should classify class access questions."""
+        assert agent._determine_query_type("What classes can Roland access?") == "class_access"
+
+    def test_general_query(self, agent):
+        """Should default to general rules."""
+        assert agent._determine_query_type("Tell me about the game") == "general_rules"
+
+
+# =============================================================================
+# Confidence Calculation Tests
+# =============================================================================
+
+
+class TestConfidenceCalculation:
+    """Tests for confidence score calculation."""
+
+    @pytest.fixture
+    def agent(self, mock_retriever):
+        """Create agent with mocked dependencies."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            with patch("backend.services.subagents.base.ChatOpenAI"):
+                return RulesAgent(retriever=mock_retriever)
+
+    @pytest.fixture
+    def mock_retriever(self):
+        retriever = MagicMock(spec=RulesRetriever)
+        retriever.search.return_value = []
+        return retriever
+
+    def test_high_confidence_with_definitive_language(self, agent):
+        """Should give high confidence for definitive statements."""
+        from backend.services.subagents.base import SubagentState
+
+        state = SubagentState(query="test", context={"_retrieved_sections": []})
+        content = "According to the rules, Roland cannot include Shrivelling."
+
+        confidence = agent._calculate_confidence(content, state)
+        assert confidence >= 0.7
+
+    def test_higher_confidence_with_retrieved_sections(self, agent):
+        """Should boost confidence when sections were retrieved."""
+        from backend.services.subagents.base import SubagentState
+
+        state = SubagentState(
+            query="test",
+            context={"_retrieved_sections": [{"section": "Test", "content": "test"}]},
+        )
+        content = "The answer is yes."
+
+        confidence = agent._calculate_confidence(content, state)
+        assert confidence > 0.5
+
+    def test_lower_confidence_with_uncertainty(self, agent):
+        """Should lower confidence for uncertain language."""
+        from backend.services.subagents.base import SubagentState
+
+        state = SubagentState(query="test", context={"_retrieved_sections": []})
+        content = "I'm not sure, but it might be allowed."
+
+        confidence = agent._calculate_confidence(content, state)
+        assert confidence < 0.5
+
+
+# =============================================================================
+# Factory Function Tests
+# =============================================================================
+
+
+class TestFactoryFunction:
+    """Tests for create_rules_agent factory."""
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch("backend.services.subagents.base.ChatOpenAI")
+    def test_create_rules_agent_default(self, mock_chat):
+        """Should create agent with default config."""
+        agent = create_rules_agent()
+
+        assert isinstance(agent, RulesAgent)
+        assert agent.agent_type == "rules"
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch("backend.services.subagents.base.ChatOpenAI")
+    def test_create_rules_agent_with_config(self, mock_chat):
+        """Should accept custom config."""
+        config = SubagentConfig(temperature=0.5, max_tokens=1024)
+        agent = create_rules_agent(config=config)
+
+        assert agent.config.temperature == 0.5
+        assert agent.config.max_tokens == 1024
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch("backend.services.subagents.base.ChatOpenAI")
+    def test_create_rules_agent_with_retriever(self, mock_chat):
+        """Should accept custom retriever."""
+        mock_retriever = MagicMock(spec=RulesRetriever)
+        agent = create_rules_agent(retriever=mock_retriever)
+
+        assert agent.retriever is mock_retriever
+
+
+# =============================================================================
+# Response Parsing Tests
+# =============================================================================
+
+
+class TestResponseParsing:
+    """Tests for LLM response parsing."""
+
+    @pytest.fixture
+    def agent(self):
+        """Create agent with mocked dependencies."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            with patch("backend.services.subagents.base.ChatOpenAI"):
+                mock_retriever = MagicMock(spec=RulesRetriever)
+                mock_retriever.search.return_value = []
+                return RulesAgent(retriever=mock_retriever)
+
+    def test_parses_structured_response(self, agent):
+        """Should parse structured markdown response."""
+        content = """**Rule**: Deck minimum is 30 cards.
+
+**Interpretation**: You must have at least 30 cards in your deck.
+
+**Applies To**: All investigators, All decks"""
+
+        rule_text, interpretation, applies_to = agent._parse_llm_response(content)
+
+        assert "30 cards" in rule_text
+        assert "at least 30 cards" in interpretation
+        assert len(applies_to) >= 2
+
+    def test_handles_unstructured_response(self, agent):
+        """Should handle responses without structure."""
+        content = "Roland can include Guardian and Seeker cards level 0-2."
+
+        rule_text, interpretation, applies_to = agent._parse_llm_response(content)
+
+        # Should fall back to using content as interpretation
+        assert interpretation == content
+        assert rule_text == ""
+
+    def test_parses_applies_to_list(self, agent):
+        """Should parse comma-separated applies_to."""
+        content = """**Rule**: Test rule
+
+**Interpretation**: Test interpretation
+
+**Applies To**: Roland Banks, Agnes Baker, All Guardians"""
+
+        _, _, applies_to = agent._parse_llm_response(content)
+
+        assert "Roland Banks" in applies_to
+        assert "Agnes Baker" in applies_to

--- a/tests/test_rules_agent_integration.py
+++ b/tests/test_rules_agent_integration.py
@@ -1,0 +1,240 @@
+"""Integration tests for RulesAgent with actual static files.
+
+These tests verify the RulesAgent works correctly with the actual
+static rules files in the project.
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.services.subagents.rules_agent import (
+    RulesAgent,
+    RulesQuery,
+    RulesResponse,
+    RulesRetriever,
+)
+from backend.services.subagents.base import SubagentConfig
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def actual_static_dir():
+    """Get the actual static directory path."""
+    return Path(__file__).parent.parent / "backend" / "static"
+
+
+@pytest.fixture
+def actual_retriever(actual_static_dir):
+    """Create retriever with actual static files."""
+    return RulesRetriever(static_dir=actual_static_dir)
+
+
+# =============================================================================
+# RulesRetriever Integration Tests
+# =============================================================================
+
+
+class TestRulesRetrieverIntegration:
+    """Integration tests for RulesRetriever with actual static files."""
+
+    def test_static_directory_exists(self, actual_static_dir):
+        """Static directory should exist."""
+        assert actual_static_dir.exists(), f"Static dir not found: {actual_static_dir}"
+
+    def test_rules_file_exists(self, actual_static_dir):
+        """Rules overview file should exist."""
+        rules_file = actual_static_dir / "rules_overview.md"
+        assert rules_file.exists(), "rules_overview.md not found"
+
+    def test_search_deckbuilding_rules(self, actual_retriever):
+        """Should find deckbuilding rules in actual files."""
+        results = actual_retriever.search("deck construction 30 cards")
+
+        assert len(results) > 0
+        # Should find content about deck construction
+        all_content = " ".join(r["content"].lower() for r in results)
+        assert "30" in all_content or "card" in all_content
+
+    def test_search_action_economy(self, actual_retriever):
+        """Should find action economy rules."""
+        results = actual_retriever.search("actions per turn investigate")
+
+        assert len(results) > 0
+        all_content = " ".join(r["content"].lower() for r in results)
+        assert "action" in all_content
+
+    def test_search_resources(self, actual_retriever):
+        """Should find resource rules."""
+        results = actual_retriever.search("resources cost play cards")
+
+        assert len(results) > 0
+
+    def test_get_all_content_includes_rules(self, actual_retriever):
+        """Should get all rules content."""
+        content = actual_retriever.get_all_rules_content()
+
+        assert len(content) > 0
+        # Should include content from rules_overview.md
+        assert "Deck Construction" in content or "deck" in content.lower()
+
+    def test_search_returns_source_info(self, actual_retriever):
+        """Should include source file info in results."""
+        results = actual_retriever.search("deck construction")
+
+        if results:
+            result = results[0]
+            assert "source" in result
+            assert result["source"].endswith(".md")
+            assert "section" in result
+            assert "content" in result
+
+
+# =============================================================================
+# RulesAgent Integration Tests (with mocked LLM)
+# =============================================================================
+
+
+class TestRulesAgentIntegration:
+    """Integration tests for RulesAgent with actual retriever but mocked LLM."""
+
+    @pytest.fixture
+    def mock_llm_response(self):
+        """Create a mock LLM response."""
+        mock_response = MagicMock()
+        mock_response.content = """**Rule**: Decks must contain a minimum of 30 cards, with 0-2 copies of each card by title.
+
+**Interpretation**: When building your deck, you need at least 30 cards total. You can include up to 2 copies of any card, but cards with different levels (like Shrivelling (0) and Shrivelling (3)) share the same title limit.
+
+**Applies To**: All investigators, All player decks"""
+        return mock_response
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch("backend.services.subagents.base.ChatOpenAI")
+    def test_agent_with_actual_retriever(
+        self, mock_chat_class, actual_retriever, mock_llm_response
+    ):
+        """Should work with actual retriever."""
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = mock_llm_response
+        mock_chat_class.return_value = mock_llm
+
+        agent = RulesAgent(retriever=actual_retriever)
+        response = agent.query("How many cards minimum in a deck?")
+
+        assert isinstance(response, RulesResponse)
+        assert response.confidence > 0
+        # Should have retrieved actual sections
+        assert response.metadata.extra.get("sections_retrieved", 0) >= 0
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch("backend.services.subagents.base.ChatOpenAI")
+    def test_prompt_includes_retrieved_rules(
+        self, mock_chat_class, actual_retriever, mock_llm_response
+    ):
+        """Should include retrieved rules in the prompt."""
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = mock_llm_response
+        mock_chat_class.return_value = mock_llm
+
+        agent = RulesAgent(retriever=actual_retriever)
+        agent.query("deck construction rules")
+
+        # Check that the system prompt includes retrieved content
+        call_args = mock_llm.invoke.call_args[0][0]
+        system_prompt = call_args[0].content
+
+        # Should have the hybrid prompt structure
+        assert "Retrieved Rule Context" in system_prompt
+        # Should have actual rules content
+        assert "30" in system_prompt or "card" in system_prompt.lower()
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch("backend.services.subagents.base.ChatOpenAI")
+    def test_sources_include_actual_files(
+        self, mock_chat_class, actual_retriever, mock_llm_response
+    ):
+        """Should include actual file references in sources."""
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = mock_llm_response
+        mock_chat_class.return_value = mock_llm
+
+        agent = RulesAgent(retriever=actual_retriever)
+        response = agent.query("deck construction rules")
+
+        # Should have sources from actual files
+        sources_str = " ".join(response.sources)
+        # At least one of these should be in sources if retrieval worked
+        assert (
+            "rules_overview" in sources_str.lower()
+            or "Deck Construction" in sources_str
+            or len(response.sources) > 0
+        )
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch("backend.services.subagents.base.ChatOpenAI")
+    def test_query_rules_with_actual_retriever(
+        self, mock_chat_class, actual_retriever, mock_llm_response
+    ):
+        """Should work with RulesQuery input."""
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = mock_llm_response
+        mock_chat_class.return_value = mock_llm
+
+        agent = RulesAgent(retriever=actual_retriever)
+        query = RulesQuery(
+            question="Can Roland include level 2 Guardian cards?",
+            investigator_id="01001",
+        )
+        response = agent.query_rules(query)
+
+        assert isinstance(response, RulesResponse)
+        assert response.rule_text != "" or response.interpretation != ""
+
+
+# =============================================================================
+# End-to-End Tests (requires OPENAI_API_KEY)
+# =============================================================================
+
+
+@pytest.mark.skipif(
+    not os.getenv("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY not set - skipping live API tests"
+)
+class TestRulesAgentLiveAPI:
+    """End-to-end tests with actual OpenAI API calls.
+
+    These tests are skipped unless OPENAI_API_KEY is set.
+    Use sparingly to avoid API costs.
+    """
+
+    def test_live_deckbuilding_query(self, actual_retriever):
+        """Test actual API call for deckbuilding question."""
+        config = SubagentConfig(max_tokens=500)  # Limit tokens for cost
+        agent = RulesAgent(config=config, retriever=actual_retriever)
+
+        response = agent.query("How many cards minimum does a deck need?")
+
+        assert isinstance(response, RulesResponse)
+        assert len(response.content) > 0
+        assert response.confidence > 0
+        # Should mention 30 cards in some form
+        assert "30" in response.content or "thirty" in response.content.lower()
+
+    def test_live_action_query(self, actual_retriever):
+        """Test actual API call for action economy question."""
+        config = SubagentConfig(max_tokens=500)
+        agent = RulesAgent(config=config, retriever=actual_retriever)
+
+        response = agent.query("How many actions does an investigator get per turn?")
+
+        assert isinstance(response, RulesResponse)
+        assert len(response.content) > 0
+        # Should mention 3 actions
+        assert "3" in response.content or "three" in response.content.lower()


### PR DESCRIPTION
## Summary

- Implements the RulesAgent subagent that handles deckbuilding rules, card restrictions, and game rule queries using a hybrid retrieval approach
- Adds `RulesRetriever` class for keyword-based search of static markdown files
- Extends base subagent pattern with rules-specific input/output schemas
- Adds comprehensive unit and integration tests

## Changes

### New Files
- `backend/services/subagents/rules_agent.py` - RulesAgent implementation with:
  - `RulesQuery` input schema (question, investigator_id, card_ids)
  - `RulesResponse` extends SubagentResponse with rule_text, interpretation, applies_to
  - `RulesRetriever` for keyword search on static files
  - Query type classification (legality_check, xp_rules, taboo_check, etc.)
  - Confidence scoring based on retrieved context
  
- `tests/test_rules_agent.py` - Unit tests with mocked LLM
- `tests/test_rules_agent_integration.py` - Integration tests with actual static files

### Modified Files
- `backend/services/subagents/__init__.py` - Export new RulesAgent classes

## Hybrid Retrieval Approach

1. **Keyword Search**: `RulesRetriever` searches static markdown files for relevant sections using topic-based keyword mapping
2. **LLM Summarization**: Retrieved rules are injected into the system prompt for context-aware interpretation

## Test plan

- [x] All 268 tests pass (49 new tests for RulesAgent)
- [x] Unit tests cover schemas, retriever, agent, query classification, confidence calculation
- [x] Integration tests verify actual static file retrieval
- [x] Live API tests available (skipped without OPENAI_API_KEY)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)