### PR TITLE
feat: add simulation metrics calculation (#17)

### DIFF
--- a/backend/models/simulation_models.py
+++ b/backend/models/simulation_models.py
@@ -42,6 +42,29 @@ class SimulationConfig(BaseModel):
     )
 
 
+class CostDistribution(BaseModel):
+    """Distribution of card costs in opening hands."""
+
+    cost_0: float = Field(ge=0.0, le=1.0, description="Proportion of 0-cost cards")
+    cost_1: float = Field(ge=0.0, le=1.0, description="Proportion of 1-cost cards")
+    cost_2: float = Field(ge=0.0, le=1.0, description="Proportion of 2-cost cards")
+    cost_3: float = Field(ge=0.0, le=1.0, description="Proportion of 3-cost cards")
+    cost_4_plus: float = Field(ge=0.0, le=1.0, description="Proportion of 4+ cost cards")
+    no_cost: float = Field(ge=0.0, le=1.0, description="Proportion of cards with no cost (skills)")
+
+
+class HandQualityBreakdown(BaseModel):
+    """Breakdown of hand quality score components."""
+
+    key_card_component: float = Field(
+        ge=0.0, le=30.0, description="Points from key card presence (0-30)"
+    )
+    cost_component: float = Field(ge=0.0, le=35.0, description="Points from cost balance (0-35)")
+    type_mix_component: float = Field(
+        ge=0.0, le=35.0, description="Points from card type diversity (0-35)"
+    )
+
+
 class KeyCardStats(BaseModel):
     """Statistics for a single key card across all trials."""
 
@@ -63,6 +86,39 @@ class KeyCardStats(BaseModel):
     )
 
 
+class SimulationMetrics(BaseModel):
+    """Aggregate performance metrics from simulation."""
+
+    # Setup and key card metrics
+    avg_setup_time: float = Field(description="Average turns to play 2+ assets")
+    avg_draws_to_key_card: float | None = Field(
+        default=None,
+        description="Average turn when first key card is drawn",
+    )
+    success_rate: float = Field(ge=0.0, le=1.0, description="Rate of key card by turn 3")
+    mulligan_rate: float = Field(ge=0.0, le=1.0, description="Rate of hands mulliganed")
+    any_key_card_rate: float = Field(
+        ge=0.0, le=1.0, description="Rate of at least one key card in opening"
+    )
+
+    # Resource analysis
+    avg_hand_cost: float = Field(ge=0.0, description="Average total cost of opening hand")
+    cost_distribution: CostDistribution = Field(
+        description="Distribution of card costs in opening hands"
+    )
+    playable_turn_1_rate: float = Field(
+        ge=0.0, le=1.0, description="Rate of hands with at least one 0-1 cost card"
+    )
+
+    # Hand quality
+    hand_quality_score: float = Field(
+        ge=0.0, le=100.0, description="Composite hand quality score (0-100)"
+    )
+    hand_quality_breakdown: HandQualityBreakdown = Field(
+        description="Breakdown of quality score components"
+    )
+
+
 class SimulationResult(BaseModel):
     """Complete results from a simulation run."""
 
@@ -71,7 +127,8 @@ class SimulationResult(BaseModel):
         description="ID of the simulated deck (if loaded from storage)",
     )
     n_trials: int = Field(description="Number of simulation trials run")
-    metrics: dict = Field(
+    mulligan_strategy: str = Field(description="Mulligan strategy used for simulation")
+    metrics: SimulationMetrics = Field(
         description="Aggregate performance metrics",
     )
     key_card_reliability: dict[str, KeyCardStats] = Field(
@@ -81,4 +138,8 @@ class SimulationResult(BaseModel):
     warnings: list[str] = Field(
         default_factory=list,
         description="Generated warnings about deck performance",
+    )
+    recommendations: list[str] = Field(
+        default_factory=list,
+        description="Suggestions for improving deck consistency",
     )


### PR DESCRIPTION
## Summary

Implements issue #17 - Simulation Metrics Calculation. Adds comprehensive metrics to the Monte Carlo simulation engine to better inform deckbuilding decisions.

- **Key Card Reliability**: `any_key_card_rate` for tracking P(at least one key card in opening)
- **Resource Analysis**: `avg_hand_cost`, `cost_distribution`, `playable_turn_1_rate`
- **Hand Quality Score**: Composite 0-100 score with component breakdown (key cards, cost balance, type mix)
- **Recommendations**: Automatic issue detection with actionable suggestions

## Test plan

- [x] 25 new unit tests added for all new metrics
- [x] Statistical property tests verify cost distribution sums to 1.0
- [x] Hand quality consistency test validates scoring across trials
- [x] Integration test verifies new schema fields in response
- [x] All 56 tests pass with 95% coverage on simulator module
- [x] `uv run pytest tests/test_simulator.py -v` passes
- [x] `uv run ruff check backend/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)